### PR TITLE
Fix `set_cooldown_from_expiration()` to accept time strings with suffix "Z" 

### DIFF
--- a/src/artifactsmmo_wrapper/__init__.py
+++ b/src/artifactsmmo_wrapper/__init__.py
@@ -196,7 +196,7 @@ class CooldownManager:
         """Set cooldown based on an ISO 8601 expiration time string."""
         with self.lock:
             # Parse the expiration time string
-            self.cooldown_expiration_time = datetime.fromisoformat(expiration_time_str)
+            self.cooldown_expiration_time = datetime.fromisoformat(expiration_time_str.replace("Z", "+00:00"))
 
     def wait_for_cooldown(self, logger=None, char=None) -> None:
         """Wait until the cooldown expires."""


### PR DESCRIPTION
Replace `Z` with `+00:00` in `expiration_time_str` in `set_cooldown_from_expiration()` so `datetime.fromisoformat()` in Python versions `<3.11` can handle it.

This fix works identically in Python versions `>=3.11` and `<3.11`. Closes #2

## Python 3.13.0
```python
Python 3.13.0 (main, Nov 19 2024, 02:19:38) [GCC 11.4.0] on linux

>>> import datetime
>>> datetime.datetime.fromisoformat("2024-01-01T02:32:21Z")
datetime.datetime(2024, 1, 1, 2, 32, 21, tzinfo=datetime.timezone.utc)
>>> datetime.datetime.fromisoformat("2024-01-01T02:32:21Z".replace("Z", "+00:00"))
datetime.datetime(2024, 1, 1, 2, 32, 21, tzinfo=datetime.timezone.utc)
```

## Python 3.10.12
```python
Python 3.10.12 (main, Nov 19 2024, 02:41:09) [GCC 11.4.0] on linux

Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> datetime.datetime.fromisoformat("2024-01-01T02:32:21Z")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Invalid isoformat string: '2024-01-01T02:32:21Z'
>>> datetime.datetime.fromisoformat("2024-01-01T02:32:21Z".replace("Z", "+00:00"))
datetime.datetime(2024, 1, 1, 2, 32, 21, tzinfo=datetime.timezone.utc)
```